### PR TITLE
Fixed bug tht throws error if an image has to be padded in both dimen…

### DIFF
--- a/test.py
+++ b/test.py
@@ -107,6 +107,7 @@ def test(file_list, model_path,roi):
             img = np.hstack((img,pad))
             img = Image.fromarray(img.astype(np.uint8))
             den = np.hstack((den,pad))
+            wd_1 = cfg.DATA.STD_SIZE[1]
             
         if ht_1 < cfg.DATA.STD_SIZE[0]:
             dif = cfg.DATA.STD_SIZE[0] - ht_1


### PR DESCRIPTION
…sions

If an image has to be padded in both directions, the lack of an update of wd_1 caused an error when concatenating arrays in the second padding (since the width was not equal to wd_1)